### PR TITLE
chore(abatilo-core): set disable-model-invocation to false for code-review

### DIFF
--- a/plugins/abatilo-core/.claude-plugin/plugin.json
+++ b/plugins/abatilo-core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "abatilo-core",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Core commands, skills, and hooks for abatilo's Claude Code setup"
 }

--- a/plugins/abatilo-core/skills/code-review/SKILL.md
+++ b/plugins/abatilo-core/skills/code-review/SKILL.md
@@ -18,6 +18,7 @@ allowed-tools:
   - SendMessage
   - WebSearch
   - WebFetch
+disable-model-invocation: false
 ---
 
 # Code Review Agent Team


### PR DESCRIPTION
## Summary
- Explicitly adds `disable-model-invocation: false` to the code-review skill frontmatter
- Bumps plugin version to 0.18.1

## Test plan
- [ ] Verify code-review skill can be invoked and model invocation is not disabled